### PR TITLE
Correct main path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-number-input",
   "version": "1.14.7",
   "description": "HTML input field designed to display formatted currency values",
-  "main": "src/react-number-input.js",
+  "main": "build/react-number-input.js",
   "scripts": {
     "prerelease": "NODE_ENV=production webpack --config webpack.prod.config.js",
     "lint": "eslint --ext .js,.jsx .",


### PR DESCRIPTION
Right now users of this component will have to use

```js
import NumberInput from 'react-number-input/build/react-number-input'
```

to import it.

This PR changes that to:

```js
import NumberInput from 'react-number-input'
```